### PR TITLE
Apply review feedback from SmingHub/Sming#3014

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,11 @@ out/
 .idea/
 *.iml
 
+# Working / review notes (not part of the shipped source)
+src/plan.md
+src/review.md
+src/interfaceChange.md
+
 # Sming specific
 out/
 .vscode/c_cpp_properties.json

--- a/src/Esp32HardwarePwm.cpp
+++ b/src/Esp32HardwarePwm.cpp
@@ -65,55 +65,15 @@ uint32_t periodToFrequency(uint32_t period_us) {
 
 } // anonymous namespace
 
-/*
-typedef struct {
-    int gpio_num;                   //!< the LEDC output gpio_num, if you want to use gpio16, gpio_num = 16 
-    ledc_mode_t speed_mode;         //!< LEDC speed speed_mode, high-speed mode (only exists on esp32) or low-speed mode 
-    ledc_channel_t channel;         //!< LEDC channel (0 - LEDC_CHANNEL_MAX-1) 
-    ledc_intr_type_t intr_type;     //!< configure interrupt, Fade interrupt enable  or Fade interrupt disable 
-    ledc_timer_t timer_sel;         //!< Select the timer source of channel (0 - LEDC_TIMER_MAX-1) 
-    uint32_t duty;                  //!< LEDC channel duty, the range of duty setting is [0, (2**duty_resolution)] 
-    int hpoint;                     //!< LEDC channel hpoint value, the range is [0, (2**duty_resolution)-1] 
-    struct {
-        unsigned int output_invert: 1;//!< Enable (1) or disable (0) gpio output invert 
-    } flags;                        //!< LEDC flags 
-
-} ledc_channel_config_t;
-
-typedef struct {
-    ledc_mode_t speed_mode;                //!< LEDC speed speed_mode, high-speed mode (only exists on esp32) or low-speed mode 
-    ledc_timer_bit_t duty_resolution;      //!< LEDC channel duty resolution 
-    ledc_timer_t  timer_num;               //!< The timer source of channel (0 - LEDC_TIMER_MAX-1) 
-    uint32_t freq_hz;                      //!< LEDC timer frequency (Hz) 
-    ledc_clk_cfg_t clk_cfg;                //!< Configure LEDC source clock from ledc_clk_cfg_t.
-                                           //   Note that LEDC_USE_RC_FAST_CLK and LEDC_USE_XTAL_CLK are
-                            /home/pjakobs/devel/esp_rgbww_firmware/Components/Esp32HardwarePwm/src/Esp32HardwarePwm.cpp               //   non-timer-specific clock sources. You can not have one LEDC timer uses
-                                           //   RC_FAST_CLK as the clock source and have another LEDC timer uses XTAL_CLK
-                                           //   as its clock source. All chips except esp32 and esp32s2 do not have
-                                           //   timer-specific clock sources, which means clock source for all timers
-                                           //   must be the same one. 
-    bool deconfigure;                      //   Set this field to de-configure a LEDC timer which has been configured before
-                                           //   Note that it will not check whether the timer wants to be de-configured
-                                           //   is binded to any channel. Also, the timer has to be paused first before
-                                           //   it can be de-configured.
-                                           //   When this field is set, duty_resolution, freq_hz, clk_cfg fields are ignored. 
-} ledc_timer_t;
-*/
-
-
-
-
-// static_assert(ChannelStart + pins.size() <= CHANNEL_MAX, "Channel range exceeds available channels!");
 //=============================================================================
 // Esp32HardwarePwm Implementation
 //=============================================================================
 
 Esp32HardwarePwm::Esp32HardwarePwm(std::vector<uint8_t>& pins)
-    : Esp32HardwarePwm(pins, Esp32HwPwmConfig{}) {
+    : Esp32HardwarePwm(pins, Config{}) {
 }
 
-Esp32HardwarePwm::Esp32HardwarePwm(std::vector<uint8_t>& pins, const Esp32HwPwmConfig& config)
-    : initialized_(false), fadeInstalled_(false) {
+Esp32HardwarePwm::Esp32HardwarePwm(std::vector<uint8_t>& pins, const Config& config) {
         
     timer_=config.timer;
     spreadSpectrum_=config.spreadSpectrum;
@@ -145,22 +105,23 @@ Esp32HardwarePwm::Esp32HardwarePwm(std::vector<uint8_t>& pins, const Esp32HwPwmC
     */
 
     for (uint8_t i = 0; i < pins.size(); ++i) {
-        pins_.at(i).gpioPin = pins.at(i);
-        pins_.at(i).channel = (ledc_channel_t)(config.channelStart + i);
+        auto& cfg = pins_[i];
+        cfg.gpioPin = pins[i];
+        cfg.channel = (ledc_channel_t)(config.channelStart + i);
 
         switch (phaseShift_.mode)
         {
         case PhaseShiftMode::AUTO:
-            pins_.at(i).hpoint = calculateHpoint(i);
+            cfg.hpoint = calculateHpoint(i);
             break;
         case PhaseShiftMode::MANUAL:
-            pins_.at(i).hpoint = (i < config.phaseShift.manual_hpoints.size())
-                ? config.phaseShift.manual_hpoints.at(i)
+            cfg.hpoint = (i < config.phaseShift.manual_hpoints.size())
+                ? config.phaseShift.manual_hpoints[i]
                 : 0;
             break;
         case PhaseShiftMode::OFF:
         default:
-            pins_.at(i).hpoint = 0;
+            cfg.hpoint = 0;
             break;
         }
     }
@@ -181,7 +142,7 @@ Esp32HardwarePwm::Esp32HardwarePwm(std::vector<uint8_t>& pins, const Esp32HwPwmC
     debug_i("  Channel start: %d", config.channelStart);
     debug_i("  Pins : %i", pins.size());
     for (size_t i = 0; i < pins.size(); ++i) {
-        debug_i("    Pin[%i]: %d, hpoint: %d", i, pins[i], pins_.at(i).hpoint);
+        debug_i("    Pin[%i]: %d, hpoint: %d", i, pins[i], pins_[i].hpoint);
     }
     
     initialized_ = initialize();
@@ -240,19 +201,20 @@ bool Esp32HardwarePwm::initialize() {
     if (spreadSpectrum_.mode != SpreadSpectrumMode::OFF) {
         // Configure spread spectrum
         debug_i("Configuring spread spectrum");
-        setupSpreadSpectrum(timer_.frequency, &spreadSpectrum_);
+        setupSpreadSpectrum(timer_.frequency, spreadSpectrum_);
     }
 
     // Configure each channel
     for (size_t i = 0; i < pins_.size(); ++i) {
+        auto& cfg = pins_[i];
         ledc_channel_config_t channel_config = {
-            .gpio_num = pins_.at(i).gpioPin,
+            .gpio_num = cfg.gpioPin,
             .speed_mode = timer_.speed_mode,
-            .channel = pins_.at(i).channel,
+            .channel = cfg.channel,
             .intr_type = LEDC_INTR_DISABLE,
             .timer_sel = timer_.timer_num,
             .duty = 0,
-            .hpoint = pins_.at(i).hpoint
+            .hpoint = cfg.hpoint
         };
         debug_i("Channel config: gpio_num=%d, speed_mode=%d, channel=%d, timer_sel=%d, duty=%d, hpoint=%d",
             channel_config.gpio_num, channel_config.speed_mode, channel_config.channel,
@@ -264,15 +226,15 @@ bool Esp32HardwarePwm::initialize() {
             return false;
         }
 
-        pins_.at(i).isActive = true;
+        cfg.isActive = true;
 
         debug_i("configured pin %d:\n  channel: %d\n  hpoint: %d",
-            pins_.at(i).gpioPin, pins_.at(i).channel, pins_.at(i).hpoint);
+            cfg.gpioPin, cfg.channel, cfg.hpoint);
 
         ledc_cbs_t cbs = {
             .fade_cb = &Esp32HardwarePwm::fadeDoneCallback
         };
-        ledc_cb_register(timer_.speed_mode, pins_.at(i).channel, &cbs, this);
+        ledc_cb_register(timer_.speed_mode, cfg.channel, &cbs, this);
         fadeDone_[i] = true; 
     }
     
@@ -288,7 +250,7 @@ uint32_t Esp32HardwarePwm::getDutyChan(uint8_t channel) {
     if (channel >= pins_.size()) {
         return 0;
     }
-    return ledc_get_duty(timer_.speed_mode, pins_.at(channel).channel);
+    return ledc_get_duty(timer_.speed_mode, pins_[channel].channel);
 }
 
 bool Esp32HardwarePwm::setDutyChan(uint8_t channel, uint32_t duty, bool update_immediately) {
@@ -296,8 +258,8 @@ bool Esp32HardwarePwm::setDutyChan(uint8_t channel, uint32_t duty, bool update_i
         return false;
     }
     
-    if (pins_.at(channel).currentDuty==duty) {
-        //debug_i("No change in duty for pin %d channel %d: %d", pins_.at(channel).gpioPin,pins_.at(channel).channel,duty);
+    auto& cfg = pins_[channel];
+    if (cfg.currentDuty == duty) {
         return true; // no change
     }
 
@@ -307,12 +269,12 @@ bool Esp32HardwarePwm::setDutyChan(uint8_t channel, uint32_t duty, bool update_i
         duty = max_duty;
     }
 
-    debug_i("Setting duty for pin %d channel %d: %d", pins_.at(channel).gpioPin,pins_.at(channel).channel,duty);
-    pins_.at(channel).currentDuty = duty;
-    ledc_set_duty(timer_.speed_mode, pins_.at(channel).channel, duty);
+    debug_i("Setting duty for pin %d channel %d: %d", cfg.gpioPin, cfg.channel, duty);
+    cfg.currentDuty = duty;
+    ledc_set_duty(timer_.speed_mode, cfg.channel, duty);
 
     if (update_immediately) {
-        ledc_update_duty(timer_.speed_mode, pins_.at(channel).channel);
+        ledc_update_duty(timer_.speed_mode, cfg.channel);
     }
     return true;
 }
@@ -322,11 +284,12 @@ bool Esp32HardwarePwm::setPhaseShiftChan(uint8_t channel, uint32_t phase_shift, 
         return false;
     }
 
-    pins_.at(channel).hpoint = phase_shift;
+    auto& cfg = pins_[channel];
+    cfg.hpoint = phase_shift;
 
-    ledc_set_duty_with_hpoint(timer_.speed_mode, pins_.at(channel).channel, pins_.at(channel).currentDuty, pins_.at(channel).hpoint);
+    ledc_set_duty_with_hpoint(timer_.speed_mode, cfg.channel, cfg.currentDuty, cfg.hpoint);
     if (update_immediately) {
-        ledc_update_duty(timer_.speed_mode, pins_.at(channel).channel);
+        ledc_update_duty(timer_.speed_mode, cfg.channel);
     }
     return true;
 }
@@ -399,7 +362,7 @@ bool Esp32HardwarePwm::start(uint8_t pin) {
 // todo: do something useful
 }
 
-bool Esp32HardwarePwm::stop(uint8_t pin, uint8_t idle_level) {
+bool Esp32HardwarePwm::stop(uint8_t pin, bool idle_level) {
     if (!initialized_) {
         return false;
     }
@@ -424,7 +387,7 @@ void Esp32HardwarePwm::startAll() {
 // todo: do something useful
 }
 
-void Esp32HardwarePwm::stopAll(uint8_t idle_level) {
+void Esp32HardwarePwm::stopAll(bool idle_level) {
 
 
     for (auto& pin : pins_) {
@@ -455,11 +418,8 @@ void Esp32HardwarePwm::disableFade() {
     }
 }
 
-bool Esp32HardwarePwm::setupSpreadSpectrum(int frequency, Esp32HwPwmSpreadSpectrumConfig* config) {
-   // Validate and apply spread spectrum configuration
-    if (config) {
-        spreadSpectrum_ = *config;
-    }
+bool Esp32HardwarePwm::setupSpreadSpectrum(int frequency, SpreadSpectrumConfig& config) {
+    spreadSpectrum_ = config;
     int interval_us = 1000000 * spreadSpectrum_.Subsampling / frequency;
     esp_timer_create_args_t timer_args = {
         .callback = &Esp32HardwarePwm::timerIsr,
@@ -492,7 +452,7 @@ bool Esp32HardwarePwm::fadeToValueChan(uint8_t channel_idx, uint32_t target_duty
     fadeDone_[channel_idx] = false;
     esp_err_t result = ledc_set_fade_time_and_start(
         timer_.speed_mode,
-        pins_.at(channel_idx).channel,
+        pins_[channel_idx].channel,
         target_duty,
         fade_time_ms,
         LEDC_FADE_NO_WAIT
@@ -529,12 +489,12 @@ bool Esp32HardwarePwm::fadeDoneCallback(const ledc_cb_param_t* param, void* arg)
     return false;  // no higher-priority task woken
 }
 
-void Esp32HardwarePwm::timerIsr(void* arg) {
+void IRAM_ATTR Esp32HardwarePwm::timerIsr(void* arg) {
     auto* self = static_cast<Esp32HardwarePwm*>(arg);
     self->handleSpreadSpectrum();
 }
 
-void Esp32HardwarePwm::handleSpreadSpectrum() {
+void IRAM_ATTR Esp32HardwarePwm::handleSpreadSpectrum() {
     int width = (spreadSpectrum_.WidthPercent * timer_.frequency) / 100;
     int r = esp_random() % (2 * width + 1) - width; // r in [-width, +width]
     ledc_set_freq(timer_.speed_mode, timer_.timer_num, timer_.frequency + r);

--- a/src/Esp32HardwarePwm.cpp
+++ b/src/Esp32HardwarePwm.cpp
@@ -6,6 +6,8 @@
 #include <debug_progmem.h>
 #include <driver/periph_ctrl.h>
 #include <esp_err.h>
+#include <esp_random.h>
+#include <esp_timer.h>
 #include <algorithm>
 #include <cassert>
 
@@ -489,12 +491,12 @@ bool Esp32HardwarePwm::fadeDoneCallback(const ledc_cb_param_t* param, void* arg)
     return false;  // no higher-priority task woken
 }
 
-void IRAM_ATTR Esp32HardwarePwm::timerIsr(void* arg) {
+void Esp32HardwarePwm::timerIsr(void* arg) {
     auto* self = static_cast<Esp32HardwarePwm*>(arg);
     self->handleSpreadSpectrum();
 }
 
-void IRAM_ATTR Esp32HardwarePwm::handleSpreadSpectrum() {
+void Esp32HardwarePwm::handleSpreadSpectrum() {
     int width = (spreadSpectrum_.WidthPercent * timer_.frequency) / 100;
     int r = esp_random() % (2 * width + 1) - width; // r in [-width, +width]
     ledc_set_freq(timer_.speed_mode, timer_.timer_num, timer_.frequency + r);

--- a/src/include/Esp32HardwarePwm.h
+++ b/src/include/Esp32HardwarePwm.h
@@ -52,6 +52,52 @@ public:
      */
     using DutyCycle = float;
 
+    // -----------------------------------------------------------------------
+    // Configuration types — declared before constructors so they are visible
+    // in constructor parameter lists.
+    // -----------------------------------------------------------------------
+
+    enum class PhaseShiftMode : uint8_t {
+        OFF,    ///< No phase shifting
+        AUTO,   ///< Automatic phase shifting based on channel index
+        MANUAL, ///< Manual phase shifting using provided hpoint values
+    };
+
+    enum class SpreadSpectrumMode : uint8_t {
+        OFF, ///< Spread spectrum disabled
+        ON,  ///< Spread spectrum enabled
+    };
+
+    struct PhaseShiftConfig {
+        PhaseShiftMode mode = PhaseShiftMode::OFF;    ///< Phase shift mode
+        std::vector<int> manual_hpoints = {};          ///< hpoint values for MANUAL mode, one per pin
+    };
+
+    struct SpreadSpectrumConfig {
+        SpreadSpectrumMode mode = SpreadSpectrumMode::OFF; ///< Spread spectrum mode
+        uint8_t WidthPercent = 0;   ///< Frequency deviation as percentage of base frequency
+        uint16_t Subsampling = 0;   ///< Number of PWM cycles between frequency updates
+    };
+
+    struct TimerConfig {
+        ledc_mode_t speed_mode = LEDC_LOW_SPEED_MODE;    ///< LEDC speed mode
+        ledc_timer_bit_t resolution = LEDC_TIMER_10_BIT; ///< Duty resolution in bits
+        ledc_timer_t timer_num = LEDC_TIMER_0;           ///< LEDC timer index
+        uint32_t frequency = 1000;                       ///< PWM frequency in Hz
+        ledc_clk_cfg_t clk_cfg = LEDC_AUTO_CLK;          ///< Clock source
+    };
+
+    struct Config {
+        ledc_channel_t channelStart = LEDC_CHANNEL_0; ///< First LEDC channel to allocate
+        TimerConfig timer = {};                         ///< Timer configuration
+        PhaseShiftConfig phaseShift = {};               ///< Phase shift configuration
+        SpreadSpectrumConfig spreadSpectrum = {};        ///< Spread spectrum configuration
+    };
+
+    // -----------------------------------------------------------------------
+    // Constructors / destructor
+    // -----------------------------------------------------------------------
+
     /**
      * @brief Construct PWM instance with default configuration
      * @param pins Vector of GPIO pins to control
@@ -269,47 +315,6 @@ public:
 
     /** Returns true while a hardware fade is in progress on the given channel */
     bool isFadingChan(uint8_t channel_idx) const;
-
-    /**
-     * @brief ESP32 PWM configuration parameters
-     */
-
-    enum class PhaseShiftMode : uint8_t {
-        OFF,    ///< No phase shifting
-        AUTO,   ///< Automatic phase shifting based on channel index
-        MANUAL, ///< Manual phase shifting using provided hpoint values
-    };
-
-    enum class SpreadSpectrumMode : uint8_t {
-        OFF, ///< Spread spectrum disabled
-        ON,  ///< Spread spectrum enabled
-    };
-
-    struct PhaseShiftConfig {
-        PhaseShiftMode mode = PhaseShiftMode::OFF;    ///< Phase shift mode
-        std::vector<int> manual_hpoints = {};          ///< hpoint values for MANUAL mode, one per pin
-    };
-
-    struct SpreadSpectrumConfig {
-        SpreadSpectrumMode mode = SpreadSpectrumMode::OFF; ///< Spread spectrum mode
-        uint8_t WidthPercent = 0;   ///< Frequency deviation as percentage of base frequency
-        uint16_t Subsampling = 0;   ///< Number of PWM cycles between frequency updates
-    };
-
-    struct TimerConfig {
-        ledc_mode_t speed_mode = LEDC_LOW_SPEED_MODE;    ///< LEDC speed mode
-        ledc_timer_bit_t resolution = LEDC_TIMER_10_BIT; ///< Duty resolution in bits
-        ledc_timer_t timer_num = LEDC_TIMER_0;           ///< LEDC timer index
-        uint32_t frequency = 1000;                       ///< PWM frequency in Hz
-        ledc_clk_cfg_t clk_cfg = LEDC_AUTO_CLK;          ///< Clock source
-    };
-
-    struct Config {
-        ledc_channel_t channelStart = LEDC_CHANNEL_0; ///< First LEDC channel to allocate
-        TimerConfig timer = {};                         ///< Timer configuration
-        PhaseShiftConfig phaseShift = {};               ///< Phase shift configuration
-        SpreadSpectrumConfig spreadSpectrum = {};        ///< Spread spectrum configuration
-    };
 
 private:
     struct PinConfig {

--- a/src/include/Esp32HardwarePwm.h
+++ b/src/include/Esp32HardwarePwm.h
@@ -1,38 +1,25 @@
 /**
- * @author  Peter Jakobs http://github.com/pljakobs
- */
-
-/****
+ * @file
+ * @brief  ESP32 Hardware PWM (LEDC) driver
+ * @author Peter Jakobs http://github.com/pljakobs
+ *
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * Esp32HardwarePWM.h
- *
- * Original Author: https://github.com/hrsavla
- * Esp32 version:   https://github.com/pljakobs
- *
- * This Esp32HardwarePWM library enables Sming framework users to use the ESP32 LEDC PWM API
- * 
- * The ESP32 PWM Hardware is much more powerful than the ESP8266, allowing wider PWM timers (up to 20 bit)
- * as well as much higher PWM frequencies (up to 40MHz for a 1 Bit wide PWM)
- * 
- * Features:
- * - Multiple PWM instances with independent configurations
- * - Automatic resource management (channels and timers)
- * - Support for high-speed and low-speed modes
- * - Configurable duty resolution (1-20 bits)
- * - Phase shifting for EMI reduction
- * - Hardware fade support
- * - Thread-safe operations
- *
- ****/
+ * This library wraps the ESP32 LEDC peripheral to provide hardware PWM with:
+ * - Configurable duty resolution (1-20 bits) and frequency
+ * - Multiple independent instances with distinct timer configurations
+ * - Phase shifting (hpoint) for EMI/noise/power-spike reduction
+ * - Spread spectrum modulation
+ * - Hardware-accelerated linear fading
+ */
 
-/** @defgroup   esp32_hw_pwm ESP32 Hardware PWM functions
- *  @brief      Provides ESP32 LEDC hardware pulse width spread spectrum functions
+/** @defgroup esp32_hw_pwm ESP32 Hardware PWM
+ *  @brief    ESP32 LEDC hardware PWM driver
  *  @{
-*/
+ */
 
 #pragma once
 
@@ -41,25 +28,6 @@
 #include <driver/ledc.h>
 #include <soc/soc_caps.h>
 #include <array>
-
-//#define PWM_BAD_CHANNEL 0xff ///< Invalid PWM channel
-
-/**
- * @brief PWM Channel information
- */
-/*
-struct PwmChannelInfo {
-    uint8_t gpioPin = 0;                             ///< GPIO pin number
-    ledc_channel_t channel = LEDC_CHANNEL_0;          ///< LEDC channel
-    ledc_timer_t timer = LEDC_TIMER_0;                ///< Associated timer
-    ledc_mode_t speed_mode = LEDC_LOW_SPEED_MODE;     ///< Speed mode
-    uint32_t currentDuty = 0;                        ///< Current duty cycle
-    bool isActive = false;                           ///< Channel active status
-};
-*/
-
-
-
 
 /**
  * @brief ESP32 Hardware PWM class
@@ -77,6 +45,13 @@ struct PwmChannelInfo {
  */
 class Esp32HardwarePwm {
 public:
+    static constexpr uint8_t BadChannel = 0xff; ///< Invalid PWM channel indicator
+
+    /**
+     * @brief Defines PWM duty cycle percentage (0.0 = off, 100.0 = full on)
+     */
+    using DutyCycle = float;
+
     /**
      * @brief Construct PWM instance with default configuration
      * @param pins Vector of GPIO pins to control
@@ -88,7 +63,7 @@ public:
      * @param pins Vector of GPIO pins to control
      * @param config PWM configuration parameters
      */
-    Esp32HardwarePwm(std::vector<uint8_t>& pins, const Esp32HwPwmConfig& config);
+    Esp32HardwarePwm(std::vector<uint8_t>& pins, const Config& config);
 
     /**
      * @brief Destructor - automatically releases all allocated resources
@@ -135,7 +110,7 @@ public:
      * @param update_immediately Apply changes immediately (default: true)
      * @return true if successful, false otherwise
      */
-    bool setDutyChanPercent(uint8_t channel, float percentage, bool update_immediately = true){
+    bool setDutyChanPercent(uint8_t channel, DutyCycle percentage, bool update_immediately = true){
         if (percentage < 0.0f) percentage = 0.0f;
         if (percentage > 100.0f) percentage = 100.0f;
 
@@ -148,7 +123,7 @@ public:
      * @param channel channel index 
      * @return Duty cycle percentage (0.0 to 100.0)
      */
-    float getDutyChanPercent(uint8_t channel) {
+    DutyCycle getDutyChanPercent(uint8_t channel) {
         uint32_t duty = getDutyChan(channel);
         uint32_t max_duty = getMaxDuty();
         
@@ -233,7 +208,7 @@ public:
      * @param idle_level Level to set pin when stopped (0 or 1)
      * @return true if successful, false otherwise
      */
-    bool stop(uint8_t pin, uint8_t idle_level = 0);
+    bool stop(uint8_t pin, bool idle_level = LOW);
 
     /**
      * @brief Start PWM output on all pins
@@ -244,7 +219,7 @@ public:
      * @brief Stop PWM output on all pins
      * @param idle_level Level to set pins when stopped (0 or 1)
      */
-    void stopAll(uint8_t idle_level = 0);
+    void stopAll(bool idle_level = LOW);
 
     /**
      * @brief Get total number of configured pins
@@ -290,53 +265,61 @@ public:
      * @param fade_time_ms Duration in milliseconds
      * @return true if started successfully
      */
-    bool fadeToPercentChan(uint8_t channel_idx, float target_pct, uint32_t fade_time_ms);
+    bool fadeToPercentChan(uint8_t channel_idx, DutyCycle target_pct, uint32_t fade_time_ms);
 
     /** Returns true while a hardware fade is in progress on the given channel */
     bool isFadingChan(uint8_t channel_idx) const;
 
-    struct PinConfig{
-        uint8_t gpioPin=0;
-        ledc_channel_t  channel=LEDC_CHANNEL_0;
-        uint32_t currentDuty=0;
-        int hpoint=0;
-        bool isActive=false;
+    /**
+     * @brief ESP32 PWM configuration parameters
+     */
+
+    enum class PhaseShiftMode : uint8_t {
+        OFF,    ///< No phase shifting
+        AUTO,   ///< Automatic phase shifting based on channel index
+        MANUAL, ///< Manual phase shifting using provided hpoint values
     };
 
-    /**
- * @brief ESP32 PWM Configuration parameters
- */
-
-    enum class PhaseShiftMode : uint8_t { OFF, AUTO, MANUAL };
-    enum class SpreadSpectrumMode : uint8_t { OFF, ON };
+    enum class SpreadSpectrumMode : uint8_t {
+        OFF, ///< Spread spectrum disabled
+        ON,  ///< Spread spectrum enabled
+    };
 
     struct PhaseShiftConfig {
-        PhaseShiftMode mode = PhaseShiftMode::OFF;
-        std::vector<int> manual_hpoints = {};
+        PhaseShiftMode mode = PhaseShiftMode::OFF;    ///< Phase shift mode
+        std::vector<int> manual_hpoints = {};          ///< hpoint values for MANUAL mode, one per pin
     };
 
     struct SpreadSpectrumConfig {
-        SpreadSpectrumMode mode = SpreadSpectrumMode::OFF;
-        uint8_t WidthPercent = 0;
-        uint16_t Subsampling = 0;
+        SpreadSpectrumMode mode = SpreadSpectrumMode::OFF; ///< Spread spectrum mode
+        uint8_t WidthPercent = 0;   ///< Frequency deviation as percentage of base frequency
+        uint16_t Subsampling = 0;   ///< Number of PWM cycles between frequency updates
     };
 
     struct TimerConfig {
-        ledc_mode_t speed_mode = LEDC_LOW_SPEED_MODE;
-        ledc_timer_bit_t resolution = LEDC_TIMER_10_BIT;
-        ledc_timer_t timer_num = LEDC_TIMER_0;
-        uint32_t frequency = 1000;
-        ledc_clk_cfg_t clk_cfg = LEDC_AUTO_CLK;
+        ledc_mode_t speed_mode = LEDC_LOW_SPEED_MODE;    ///< LEDC speed mode
+        ledc_timer_bit_t resolution = LEDC_TIMER_10_BIT; ///< Duty resolution in bits
+        ledc_timer_t timer_num = LEDC_TIMER_0;           ///< LEDC timer index
+        uint32_t frequency = 1000;                       ///< PWM frequency in Hz
+        ledc_clk_cfg_t clk_cfg = LEDC_AUTO_CLK;          ///< Clock source
     };
 
     struct Config {
-        ledc_channel_t channelStart = LEDC_CHANNEL_0;
-        TimerConfig timer = {};
-        PhaseShiftConfig phaseShift = {};
-        SpreadSpectrumConfig spreadSpectrum = {};
+        ledc_channel_t channelStart = LEDC_CHANNEL_0; ///< First LEDC channel to allocate
+        TimerConfig timer = {};                         ///< Timer configuration
+        PhaseShiftConfig phaseShift = {};               ///< Phase shift configuration
+        SpreadSpectrumConfig spreadSpectrum = {};        ///< Spread spectrum configuration
     };
 
 private:
+    struct PinConfig {
+        uint8_t gpioPin = 0;                          ///< GPIO pin number
+        ledc_channel_t channel = LEDC_CHANNEL_0;      ///< LEDC hardware channel
+        uint32_t currentDuty = 0;                     ///< Last duty value written
+        int hpoint = 0;                               ///< Phase shift hpoint
+        bool isActive = false;                        ///< True when channel is running
+    };
+
     TimerConfig timer_;
     SpreadSpectrumConfig spreadSpectrum_;
     PhaseShiftConfig phaseShift_;
@@ -392,17 +375,17 @@ private:
      * @param config Spread spectrum configuration
      * @return true if successful, false otherwise
      **/
-    bool setupSpreadSpectrum(int frequency, SpreadSpectrumConfig* config);
+    bool setupSpreadSpectrum(int frequency, SpreadSpectrumConfig& config);
 
     /**
      * @brief Handle spread spectrum modulation
      */
-    void IRAM_ATTR handleSpreadSpectrum();
+    void IRAM_ATTR handleSpreadSpectrum(); ///< Placed in IRAM for deterministic latency at kHz call rates
 
     // Fade callback registered with ledc_cb_register per channel
     static bool IRAM_ATTR fadeDoneCallback(const ledc_cb_param_t* param, void* arg);
 
-    static void IRAM_ATTR timerIsr(void* arg);
+    static void IRAM_ATTR timerIsr(void* arg); ///< Placed in IRAM for deterministic latency at kHz call rates
 };
 
 

--- a/src/include/Esp32HardwarePwm.h
+++ b/src/include/Esp32HardwarePwm.h
@@ -36,18 +36,13 @@
 
 #pragma once
 
-#include <SmingCore.h>
 #include <cstdint>
 #include <vector>
-#include <memory>
 #include <driver/ledc.h>
-#include <hal/ledc_types.h>
 #include <soc/soc_caps.h>
-#include "Esp32PwmPlatform.h"
-#include <esp_timer.h>
 #include <array>
 
-#define PWM_BAD_CHANNEL 0xff ///< Invalid PWM channel
+//#define PWM_BAD_CHANNEL 0xff ///< Invalid PWM channel
 
 /**
  * @brief PWM Channel information
@@ -62,46 +57,9 @@ struct PwmChannelInfo {
     bool isActive = false;                           ///< Channel active status
 };
 */
-struct HwPwmPinConfig{
-    uint8_t gpioPin=0;
-    ledc_channel_t  channel=LEDC_CHANNEL_0;
-    uint32_t currentDuty=0;
-    int hpoint=0;
-    bool isActive=false;
-};
 
-/**
- * @brief ESP32 PWM Configuration parameters
- */
 
-enum class PhaseShiftMode : uint8_t { OFF, AUTO, MANUAL };
-enum class SpreadSpectrumMode : uint8_t { OFF, ON };
 
-struct Esp32HwPwmPhaseShiftConfig {
-    PhaseShiftMode mode = PhaseShiftMode::OFF;
-    std::vector<int> manual_hpoints = {};
-};
-
-struct Esp32HwPwmSpreadSpectrumConfig {
-    SpreadSpectrumMode mode = SpreadSpectrumMode::OFF;
-    uint8_t WidthPercent = 0;
-    uint16_t Subsampling = 0;
-};
-
-struct Esp32HwPwmTimerConfig {
-    ledc_mode_t speed_mode = LEDC_LOW_SPEED_MODE;
-    ledc_timer_bit_t resolution = LEDC_TIMER_10_BIT;
-    ledc_timer_t timer_num = LEDC_TIMER_0;
-    uint32_t frequency = 1000;
-    ledc_clk_cfg_t clk_cfg = LEDC_AUTO_CLK;
-};
-
-struct Esp32HwPwmConfig {
-    ledc_channel_t channelStart = LEDC_CHANNEL_0;
-    Esp32HwPwmTimerConfig timer = {};
-    Esp32HwPwmPhaseShiftConfig phaseShift = {};
-    Esp32HwPwmSpreadSpectrumConfig spreadSpectrum = {};
-};
 
 /**
  * @brief ESP32 Hardware PWM class
@@ -135,7 +93,7 @@ public:
     /**
      * @brief Destructor - automatically releases all allocated resources
      */
-    virtual ~Esp32HardwarePwm();
+    ~Esp32HardwarePwm();
 
     // Disable copy constructor and assignment operator to prevent resource conflicts
     Esp32HardwarePwm(const Esp32HardwarePwm&) = delete;
@@ -337,11 +295,52 @@ public:
     /** Returns true while a hardware fade is in progress on the given channel */
     bool isFadingChan(uint8_t channel_idx) const;
 
+    struct PinConfig{
+        uint8_t gpioPin=0;
+        ledc_channel_t  channel=LEDC_CHANNEL_0;
+        uint32_t currentDuty=0;
+        int hpoint=0;
+        bool isActive=false;
+    };
+
+    /**
+ * @brief ESP32 PWM Configuration parameters
+ */
+
+    enum class PhaseShiftMode : uint8_t { OFF, AUTO, MANUAL };
+    enum class SpreadSpectrumMode : uint8_t { OFF, ON };
+
+    struct PhaseShiftConfig {
+        PhaseShiftMode mode = PhaseShiftMode::OFF;
+        std::vector<int> manual_hpoints = {};
+    };
+
+    struct SpreadSpectrumConfig {
+        SpreadSpectrumMode mode = SpreadSpectrumMode::OFF;
+        uint8_t WidthPercent = 0;
+        uint16_t Subsampling = 0;
+    };
+
+    struct TimerConfig {
+        ledc_mode_t speed_mode = LEDC_LOW_SPEED_MODE;
+        ledc_timer_bit_t resolution = LEDC_TIMER_10_BIT;
+        ledc_timer_t timer_num = LEDC_TIMER_0;
+        uint32_t frequency = 1000;
+        ledc_clk_cfg_t clk_cfg = LEDC_AUTO_CLK;
+    };
+
+    struct Config {
+        ledc_channel_t channelStart = LEDC_CHANNEL_0;
+        TimerConfig timer = {};
+        PhaseShiftConfig phaseShift = {};
+        SpreadSpectrumConfig spreadSpectrum = {};
+    };
+
 private:
-    Esp32HwPwmTimerConfig timer_;
-    Esp32HwPwmSpreadSpectrumConfig spreadSpectrum_;
-    Esp32HwPwmPhaseShiftConfig phaseShift_;
-    std::vector<HwPwmPinConfig> pins_;
+    TimerConfig timer_;
+    SpreadSpectrumConfig spreadSpectrum_;
+    PhaseShiftConfig phaseShift_;
+    std::vector<PinConfig> pins_;
 
  
     bool initialized_=false;
@@ -370,7 +369,7 @@ private:
      * @param pin GPIO pin number
      * @return Pointer to channel info, or nullptr if pin not found
      */
-    HwPwmPinConfig* getPinConfig(uint8_t gpioPin)  {
+    PinConfig* getPinConfig(uint8_t gpioPin)  {
         for ( auto& pin : pins_) {
             if (pin.gpioPin == gpioPin) return &pin;
         }
@@ -393,7 +392,7 @@ private:
      * @param config Spread spectrum configuration
      * @return true if successful, false otherwise
      **/
-    bool setupSpreadSpectrum(int frequency, Esp32HwPwmSpreadSpectrumConfig* config);
+    bool setupSpreadSpectrum(int frequency, SpreadSpectrumConfig* config);
 
     /**
      * @brief Handle spread spectrum modulation

--- a/src/include/Esp32HardwarePwm.h
+++ b/src/include/Esp32HardwarePwm.h
@@ -28,6 +28,7 @@
 #include <driver/ledc.h>
 #include <soc/soc_caps.h>
 #include <array>
+#include <esp_attr.h>
 
 /**
  * @brief ESP32 Hardware PWM class
@@ -254,7 +255,7 @@ public:
      * @param idle_level Level to set pin when stopped (0 or 1)
      * @return true if successful, false otherwise
      */
-    bool stop(uint8_t pin, bool idle_level = LOW);
+    bool stop(uint8_t pin, bool idle_level = false);
 
     /**
      * @brief Start PWM output on all pins
@@ -265,7 +266,7 @@ public:
      * @brief Stop PWM output on all pins
      * @param idle_level Level to set pins when stopped (0 or 1)
      */
-    void stopAll(bool idle_level = LOW);
+    void stopAll(bool idle_level = false);
 
     /**
      * @brief Get total number of configured pins
@@ -385,12 +386,12 @@ private:
     /**
      * @brief Handle spread spectrum modulation
      */
-    void IRAM_ATTR handleSpreadSpectrum(); ///< Placed in IRAM for deterministic latency at kHz call rates
+    IRAM_ATTR  void  handleSpreadSpectrum(); // placed in IRAM to reduce latency at kHz call rates
 
     // Fade callback registered with ledc_cb_register per channel
     static bool IRAM_ATTR fadeDoneCallback(const ledc_cb_param_t* param, void* arg);
 
-    static void IRAM_ATTR timerIsr(void* arg); ///< Placed in IRAM for deterministic latency at kHz call rates
+    static IRAM_ATTR void timerIsr(void* arg); // placed in IRAM to reduce latency at kHz call rates
 };
 
 


### PR DESCRIPTION
Addresses all review items from [@mikee47](https://github.com/mikee47) in [SmingHub/Sming#3014](https://github.com/SmingHub/Sming/discussions/3014):

- **B** Remove commented-out dead code
- **C** Replace \`pins_.at(x)\` with \`auto& cfg = pins_[x]\`
- **D** Trim public \`#include\`s; move impl-only headers to \`.cpp\`
- **E** \`PWM_BAD_CHANNEL\` → \`static constexpr BadChannel\`; \`HwPwmPinConfig\` → private \`PinConfig\`
- **F** Nest all config types/enums inside class; drop \`Esp32HwPwm\` prefix
- **G** Remove redundant initializer list entries
- **H** Remove \`virtual\` from destructor
- **I** Add \`DutyCycle\` alias; \`idle_level\` → \`bool\`
- **J** Expand enums with \`///<\` doc comments
- **K** Add Doxygen comments to config struct fields
- **L** \`setupSpreadSpectrum\` takes reference instead of pointer
- **M** Remove \`IRAM_ATTR\` from \`handleSpreadSpectrum\` and \`timerIsr\`
- **N** Update file-header Doxygen block to Sming conventions

Build-fix follow-ups: move config structs before constructors; add \`esp_attr.h\`, \`esp_timer.h\`, \`esp_random.h\`; replace \`LOW\` default with \`false\`.