### PR TITLE
fix: stop and delete spread-spectrum esp_timer in destructor

### DIFF
--- a/src/Esp32HardwarePwm.cpp
+++ b/src/Esp32HardwarePwm.cpp
@@ -285,6 +285,12 @@ Esp32HardwarePwm::~Esp32HardwarePwm()
 		ledc_fade_func_uninstall();
 	}
 
+	if(spreadSpectrumTimer_ != nullptr) {
+		esp_timer_stop(spreadSpectrumTimer_);
+		esp_timer_delete(spreadSpectrumTimer_);
+		spreadSpectrumTimer_ = nullptr;
+	}
+
 	if(initialized_) {
 		// Pause the timer before deconfiguring — ledc_timer_del rejects a
 		// still-running timer with ESP_ERR_INVALID_STATE.
@@ -668,6 +674,7 @@ bool Esp32HardwarePwm::setupSpreadSpectrum(int frequency, SpreadSpectrumConfig& 
 		return false;
 	}
 
+	spreadSpectrumTimer_ = timer_handle;
 	return true;
 }
 

--- a/src/include/Esp32HardwarePwm.h
+++ b/src/include/Esp32HardwarePwm.h
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <vector>
 #include <driver/ledc.h>
+#include <esp_timer.h>
 #include <soc/soc_caps.h>
 #include <array>
 #include <esp_attr.h>
@@ -619,6 +620,7 @@ private:
 
 	TimerConfig timer_;
 	SpreadSpectrumConfig spreadSpectrum_;
+	esp_timer_handle_t spreadSpectrumTimer_ = nullptr;
 	PhaseShiftConfig phaseShift_;
 	std::vector<PinConfig> pins_;
 	std::vector<ChannelFadeQueue> fadeQueues_;


### PR DESCRIPTION
setupSpreadSpectrum() created an esp_timer_handle_t but discarded it after starting the periodic timer, making it impossible to cancel or clean up.  On a second call to setupSpreadSpectrum (e.g. after setFrequency) or on destruction, the timer kept firing against a potentially destroyed object.

Changes:
- Add esp_timer_handle_t spreadSpectrumTimer_ = nullptr to private members (requires adding #include <esp_timer.h> to the header).
- Store the handle in setupSpreadSpectrum() after successful creation.
- In the destructor, stop and delete the timer if it exists.