### PR TITLE
fix: use std::atomic<uint32_t> for pendingFadeCallbacks_

### DIFF
--- a/src/Esp32HardwarePwm.cpp
+++ b/src/Esp32HardwarePwm.cpp
@@ -170,7 +170,7 @@ void Esp32HardwarePwm::steadyFadeTimerCb(void* arg)
 	auto* ctx = static_cast<SteadyFadeContext*>(arg);
 	auto* self = ctx->self;
 	uint8_t channel_idx = ctx->channel_idx;
-	self->pendingFadeCallbacks_ |= (1u << channel_idx);
+	self->pendingFadeCallbacks_.fetch_or(1u << channel_idx, std::memory_order_relaxed);
 	if(!self->fadeCallbackQueued_) {
 		self->fadeCallbackQueued_ = true;
 		System.queueCallback(Esp32HardwarePwm::dispatchFadeCallbacks, reinterpret_cast<uint32_t>(self));
@@ -678,7 +678,7 @@ bool IRAM_ATTR Esp32HardwarePwm::fadeDoneCallback(const ledc_cb_param_t* param, 
 	if(i < self->pins_.size()) {
 		self->pins_[i].currentDuty = self->pins_[i].targetDuty;
 		self->fadeDone_[i] = true;
-		self->pendingFadeCallbacks_ |= (1u << i);
+		self->pendingFadeCallbacks_.fetch_or(1u << i, std::memory_order_relaxed);
 		if(!self->fadeCallbackQueued_) {
 			self->fadeCallbackQueued_ = true;
 			System.queueCallback(dispatchFadeCallbacks, reinterpret_cast<uint32_t>(self));
@@ -727,9 +727,9 @@ void Esp32HardwarePwm::dispatchFadeCallbacks(uint32_t param)
 	auto* self = reinterpret_cast<Esp32HardwarePwm*>(param);
 	self->fadeCallbackQueued_ = false;
 
-	// Snapshot and clear the bitmask atomically in task context
-	uint32_t pending = self->pendingFadeCallbacks_;
-	self->pendingFadeCallbacks_ = 0;
+	// Atomically snapshot-and-clear: any ISR firing between the load and the
+	// clear would be lost with two separate operations.
+	uint32_t pending = self->pendingFadeCallbacks_.exchange(0, std::memory_order_acq_rel);
 
 	for(uint8_t i = 0; i < self->pins_.size(); ++i) {
 		if(!(pending & (1u << i)))
@@ -851,7 +851,7 @@ bool Esp32HardwarePwm::startNextFade(uint8_t channel_idx)
 			return false;
 		q.activeIsIntermediate = entry.isPartial;
 		if(entry.fadeTimeMs == 0) {
-			pendingFadeCallbacks_ |= (1u << channel_idx);
+			pendingFadeCallbacks_.fetch_or(1u << channel_idx, std::memory_order_relaxed);
 			if(!fadeCallbackQueued_) {
 				fadeCallbackQueued_ = true;
 				System.queueCallback(dispatchFadeCallbacks, reinterpret_cast<uint32_t>(this));

--- a/src/include/Esp32HardwarePwm.h
+++ b/src/include/Esp32HardwarePwm.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <vector>
 #include <driver/ledc.h>
@@ -519,7 +520,7 @@ public:
 	 */
 	bool hasPendingCallbacks() const
 	{
-		return pendingFadeCallbacks_ != 0 || fadeCallbackQueued_;
+		return pendingFadeCallbacks_.load(std::memory_order_relaxed) != 0 || fadeCallbackQueued_;
 	}
 
 	// -----------------------------------------------------------------------
@@ -630,7 +631,10 @@ private:
 	std::array<volatile bool, SOC_LEDC_CHANNEL_NUM> fadeDone_{};
 
 	// ISR → task handoff for fade completion
-	volatile uint32_t pendingFadeCallbacks_ = 0;
+	// Written from the LEDC fade ISR (potentially on either core) and
+	// read+cleared in task context — must be atomic to avoid torn reads
+	// on the dual-core ESP32.
+	std::atomic<uint32_t> pendingFadeCallbacks_{0};
 	volatile bool fadeCallbackQueued_ = false;
 
 	// Application-level callbacks


### PR DESCRIPTION
On a dual-core ESP32 the LEDC fade-done ISR can fire on either core while dispatchFadeCallbacks() runs on the other.  The former |=-s a bit; the latter reads and clears the field.  With a plain volatile uint32_t these operations are not atomic: the read-modify- write on Xtensa is two separate instructions, so a concurrent ISR can silently lose a bit.

Changes:
- #include <atomic> in Esp32HardwarePwm.h.
- Change member to std::atomic<uint32_t> pendingFadeCallbacks_{0}.
- fadeDoneCallback (ISR): |= → fetch_or(…, memory_order_relaxed).
- steadyFadeTimerCb:      |= → fetch_or(…, memory_order_relaxed).
- handleZeroRangeFade lambda: |= → fetch_or(…, memory_order_relaxed).
- dispatchFadeCallbacks: two-step read+clear → exchange(0, acq_rel),
  which atomically takes all bits and ensures prior ISR writes are
  visible before the loop runs.
- hasPendingCallbacks(): != 0 → .load(memory_order_relaxed) != 0.