### PR TITLE
refactor: unify fade API — fadeChan/fadePercentChan with queue+cie flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ Esp32HardwarePwm pwm(led_pins, Esp32HardwarePwm::Config{
 
 void init() {
     if (pwm.isInitialized()) {
-        pwm.fadeToValueChan(0, pwm.getMaxDuty(), 2000);  // fade to 100% over 2 s
-        pwm.fadeToPercentChan(1, 50.0f, 1500);           // fade to 50% over 1.5 s
+        pwm.fadeChan(0, pwm.getMaxDuty(), 2000);         // fade to 100% over 2 s
+        pwm.fadePercentChan(1, 50.0f, 1500);               // fade to 50% over 1.5 s
     }
 }
 ```
@@ -203,13 +203,15 @@ Channels are zero-indexed in the order the pins were supplied to the constructor
 ```cpp
 bool     setDutyChan(uint8_t channel, uint32_t duty, bool update_immediately = true);
 uint32_t getDutyChan(uint8_t channel);
+bool     setDutyChanPercent(uint8_t channel, float pct, bool update_immediately = true, bool cie = false);
+float    getDutyChanPercent(uint8_t channel, bool cie = false);  // cie=true → inverse CIE 1931
 bool     setPhaseShiftChan(uint8_t channel, uint32_t phase_shift, bool update_immediately = true);
 ```
 
 ##### Pin interface (legacy)
 ```cpp
-bool     setDuty(uint8_t pin, uint32_t duty, bool update_immediately = true);
-uint32_t getDuty(uint8_t pin);
+bool     setDutyPin(uint8_t pin, uint32_t duty, bool update_immediately = true);
+uint32_t getDutyPin(uint8_t pin);
 bool     analogWrite(uint8_t pin, uint32_t duty);
 ```
 
@@ -248,10 +250,10 @@ Fade support is installed automatically on first use.
 bool enableFade();    // install LEDC fade ISR (called automatically by fade methods)
 void disableFade();
 
-// Fade to an absolute duty value
-bool fadeToValueChan(uint8_t channel, uint32_t target_duty, uint32_t fade_time_ms);
-// Fade to a percentage (0.0 – 100.0)
-bool fadeToPercentChan(uint8_t channel, float target_pct, uint32_t fade_time_ms);
+// Immediate fade (resets queue, starts now); queue=true enqueues instead
+bool fadeChan(uint8_t channel, uint32_t target_duty, uint32_t fade_time_ms, bool queue = false);
+// Same but target is a percentage (0.0 – 100.0); cie=true applies CIE 1931 correction
+bool fadePercentChan(uint8_t channel, float target_pct, uint32_t fade_time_ms, bool cie = false, bool queue = false);
 // Returns true while a hardware fade is in progress
 bool isFadingChan(uint8_t channel) const;
 ```
@@ -266,7 +268,7 @@ be changed per-channel at runtime before the queue is filled.
 
 | Mode | Behaviour | Auto-start |
 |------|-----------|------------|
-| `FIFO` (default) | Entries play once in order; `onQueueEmpty` fires when exhausted | Yes — playback starts on first `queueFadeChan()` call |
+| `FIFO` (default) | Entries play once in order; `onQueueEmpty` fires when exhausted | Yes — playback starts on first `fadeChan(..., queue=true)` call |
 | `CYCLIC` | Entries loop endlessly back to entry 0; `onCyclicWrap` fires each loop | No — call `startQueue()` after seeding all entries |
 
 ##### Queue management
@@ -290,9 +292,9 @@ void     resetQueue(uint8_t channel);            // clear queue, preserve capaci
 ##### Enqueueing and starting
 
 ```cpp
-// Enqueue a fade (absolute duty or percentage)
-bool queueFadeChan(uint8_t channel, uint32_t targetDuty, uint32_t fadeTimeMs);
-bool queueFadePercentChan(uint8_t channel, float targetPct, uint32_t fadeTimeMs);
+// Enqueue a fade: fadeChan/fadePercentChan with queue=true
+bool fadeChan(uint8_t channel, uint32_t targetDuty, uint32_t fadeTimeMs, bool queue = false);
+bool fadePercentChan(uint8_t channel, float targetPct, uint32_t fadeTimeMs, bool cie = false, bool queue = false);
 
 // Explicitly start a CYCLIC queue (or restart an idle FIFO queue)
 bool startQueue(uint8_t channel);
@@ -315,9 +317,9 @@ pwm.setOnCyclicWrapCallback([](uint8_t ch) { ... });
 
 ```cpp
 pwm.setQueueMode(1, Esp32HardwarePwm::QueueMode::CYCLIC);
-pwm.queueFadePercentChan(1, 100.0f, 1000);
-pwm.queueFadePercentChan(1,   0.0f, 1000);
-pwm.queueFadePercentChan(1,  50.0f, 1000);
+pwm.fadePercentChan(1, 100.0f, 1000, false, true);
+pwm.fadePercentChan(1,   0.0f, 1000, false, true);
+pwm.fadePercentChan(1,  50.0f, 1000, false, true);
 pwm.startQueue(1);  // must be called after seeding; CYCLIC does not auto-start
 ```
 
@@ -375,7 +377,7 @@ than requested.  For example:
 The library warns once per channel whenever `1 ≤ cycle_num < 20`:
 
 ```
-queueFadeChan: ch0 cycle_num=3 (< 20) — fade may be 929 ms short (hw limit).
+fadeChan: ch0 cycle_num=3 (< 20) — fade may be 929 ms short (hw limit).
 Fix: increase fadeTimeMs, lower resolution, or raise frequency to >= 20475 Hz
 ```
 

--- a/samples/Advanced_HwPWM/app/application.cpp
+++ b/samples/Advanced_HwPWM/app/application.cpp
@@ -49,7 +49,7 @@ void startNextFade()
 {
 	// Alternate between fading to 100% and back to 0%
 	static bool countUp = true;
-	pwm.fadeToPercentChanCie(LED_CHANNEL, countUp ? 100.0f : 0.0f, FADE_TIME_MS);
+	pwm.fadePercentChan(LED_CHANNEL, countUp ? 100.0f : 0.0f, FADE_TIME_MS, true);
 	countUp = !countUp;
 }
 
@@ -82,7 +82,7 @@ SimpleTimer chaseTimer;
 	static uint8_t currentChannel = 0;
 
 	pwm.setDutyChanPercent(currentChannel, 100.0f);
-	pwm.fadeToPercentChan(currentChannel, 0.0f, CHASE_FADE_MS);
+	pwm.fadePercentChan(currentChannel, 0.0f, CHASE_FADE_MS);
 
 	currentChannel = (currentChannel + 1) % pwm.getPinCount();
 }
@@ -99,7 +99,7 @@ void init()
 
 	// Set default duty on every channel
 	for(uint8_t ch = 0; ch < pwm.getPinCount(); ++ch) {
-		pwm.setDutyChanCiePercent(ch, defaultDutyPercent[ch]);
+		pwm.setDutyChanPercent(ch, defaultDutyPercent[ch], true, true);
 	}
 
 	Serial << _F("PWM output set on all ") << pwm.getPinCount() << _F(" channels.") << endl;

--- a/samples/Callbacks_HwPWM/app/application.cpp
+++ b/samples/Callbacks_HwPWM/app/application.cpp
@@ -68,9 +68,9 @@ uint32_t streamStepsPushed = 0; ///< Steps pushed to CH3 so far
 // -----------------------------------------------------------------------
 void armCh1Fifo()
 {
-	pwm.queueFadePercentChan(CH_QUEUE_EMPTY, 100.0f, STEP_MS);
-	pwm.queueFadePercentChan(CH_QUEUE_EMPTY, 50.0f, STEP_MS);
-	pwm.queueFadePercentChan(CH_QUEUE_EMPTY, 0.0f, STEP_MS);
+	pwm.fadePercentChan(CH_QUEUE_EMPTY, 100.0f, STEP_MS, false, true);
+	pwm.fadePercentChan(CH_QUEUE_EMPTY, 50.0f, STEP_MS, false, true);
+	pwm.fadePercentChan(CH_QUEUE_EMPTY, 0.0f, STEP_MS, false, true);
 }
 
 // -----------------------------------------------------------------------
@@ -82,7 +82,7 @@ void pushStreamStep()
 {
 	uint8_t pos = static_cast<uint8_t>(streamStepsPushed % 20);
 	float pct = (pos < 10) ? (pos + 1) * 10.0f : (19 - pos) * 10.0f;
-	pwm.queueFadePercentChan(CH_STREAM, pct, STREAM_STEP_MS);
+	pwm.fadePercentChan(CH_STREAM, pct, STREAM_STEP_MS, false, true);
 	++streamStepsPushed;
 	Serial.printf("[stream      ] ch=%u  step %2lu/%lu -> %.0f%%\n", (unsigned)CH_STREAM,
 				  (unsigned long)streamStepsPushed, (unsigned long)TOTAL_STREAM_STEPS, (double)pct);
@@ -153,11 +153,11 @@ void startDemo()
 	// -------------------------------------------------------------------
 	pwm.setQueueCapacity(CH_FADE_DONE, 6);
 	pwm.setQueueAutoStart(CH_FADE_DONE, true);
-	pwm.queueFadePercentChan(CH_FADE_DONE, 0.0f, STEP_MS);
-	pwm.queueFadePercentChan(CH_FADE_DONE, 25.0f, STEP_MS);
-	pwm.queueFadePercentChan(CH_FADE_DONE, 75.0f, STEP_MS);
-	pwm.queueFadePercentChan(CH_FADE_DONE, 100.0f, STEP_MS);
-	pwm.queueFadePercentChan(CH_FADE_DONE, 50.0f, STEP_MS);
+pwm.fadePercentChan(CH_FADE_DONE, 0.0f, STEP_MS, false, true);
+		pwm.fadePercentChan(CH_FADE_DONE, 25.0f, STEP_MS, false, true);
+		pwm.fadePercentChan(CH_FADE_DONE, 75.0f, STEP_MS, false, true);
+		pwm.fadePercentChan(CH_FADE_DONE, 100.0f, STEP_MS, false, true);
+		pwm.fadePercentChan(CH_FADE_DONE, 50.0f, STEP_MS, false, true);
 
 	// -------------------------------------------------------------------
 	// CH1 — onQueueEmpty: initial 3-step FIFO load
@@ -171,10 +171,10 @@ void startDemo()
 	// -------------------------------------------------------------------
 	pwm.setQueueCapacity(CH_CYCLIC_WRAP, 5);
 	pwm.setQueueMode(CH_CYCLIC_WRAP, Esp32HardwarePwm::QueueMode::CYCLIC);
-	pwm.queueFadePercentChan(CH_CYCLIC_WRAP, 0.0f, STEP_MS);
-	pwm.queueFadePercentChan(CH_CYCLIC_WRAP, 100.0f, STEP_MS);
-	pwm.queueFadePercentChan(CH_CYCLIC_WRAP, 20.0f, STEP_MS);
-	pwm.queueFadePercentChan(CH_CYCLIC_WRAP, 100.0f, STEP_MS);
+		pwm.fadePercentChan(CH_CYCLIC_WRAP, 0.0f, STEP_MS, false, true);
+		pwm.fadePercentChan(CH_CYCLIC_WRAP, 100.0f, STEP_MS, false, true);
+		pwm.fadePercentChan(CH_CYCLIC_WRAP, 20.0f, STEP_MS, false, true);
+		pwm.fadePercentChan(CH_CYCLIC_WRAP, 100.0f, STEP_MS, false, true);
 	pwm.startQueue(CH_CYCLIC_WRAP);
 
 	// -------------------------------------------------------------------

--- a/samples/FadeQueue_HwPWM/app/application.cpp
+++ b/samples/FadeQueue_HwPWM/app/application.cpp
@@ -84,31 +84,31 @@ void setupFadeQueueDemo()
 	Serial.println(_F("Channel 0: FIFO — queuing 3 fades (100%->0%->50%->0%->100%->50%)"));
 	// Mode defaults to FIFO; no setQueueMode call needed
 	pwm.setQueueCapacity(0, 25);
-	pwm.queueFadePercentChan(0, 100.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 0.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 50.0f, FADE_MS / 2);
-	pwm.queueFadePercentChan(0, 0.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 100.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 50.0f, FADE_MS);
-	pwm.queueFadePercentChan(0, 100.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 0.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 50.0f, FADE_MS / 2);
-	pwm.queueFadePercentChan(0, 0.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 100.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 50.0f, FADE_MS);
-	pwm.queueFadePercentChan(0, 100.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 0.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 50.0f, FADE_MS / 2);
-	pwm.queueFadePercentChan(0, 0.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 100.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 50.0f, FADE_MS);
-	pwm.queueFadePercentChan(0, 100.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 0.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 50.0f, FADE_MS / 2);
-	pwm.queueFadePercentChan(0, 0.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 100.0f, FADE_MS / 5);
-	pwm.queueFadePercentChan(0, 50.0f, FADE_MS);
-	pwm.queueFadePercentChan(0, 0.0f, 5000);
+	pwm.fadePercentChan(0, 100.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 0.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 50.0f, FADE_MS / 2, false, true);
+	pwm.fadePercentChan(0, 0.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 100.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 50.0f, FADE_MS, false, true);
+	pwm.fadePercentChan(0, 100.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 0.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 50.0f, FADE_MS / 2, false, true);
+	pwm.fadePercentChan(0, 0.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 100.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 50.0f, FADE_MS, false, true);
+	pwm.fadePercentChan(0, 100.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 0.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 50.0f, FADE_MS / 2, false, true);
+	pwm.fadePercentChan(0, 0.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 100.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 50.0f, FADE_MS, false, true);
+	pwm.fadePercentChan(0, 100.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 0.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 50.0f, FADE_MS / 2, false, true);
+	pwm.fadePercentChan(0, 0.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 100.0f, FADE_MS / 5, false, true);
+	pwm.fadePercentChan(0, 50.0f, FADE_MS, false, true);
+	pwm.fadePercentChan(0, 0.0f, 5000, false, true);
 	// ------------------------------------------------------------------
 	// Channel 1: CYCLIC — 3 entries loop until resetQueue() is called
 	// ------------------------------------------------------------------
@@ -116,10 +116,10 @@ void setupFadeQueueDemo()
 	pwm.setQueueMode(1, Esp32HardwarePwm::QueueMode::CYCLIC);
 	// Demonstrate runtime-configurable queue depth (4 slots instead of default 10)
 	pwm.setQueueCapacity(1, 4);
-	pwm.queueFadePercentChan(1, 100.0f, FADE_MS);
-	pwm.queueFadePercentChan(1, 0.0f, FADE_MS);
-	pwm.queueFadePercentChan(1, 50.0f, FADE_MS);
-	pwm.queueFadePercentChan(1, 0.0f, FADE_MS);
+	pwm.fadePercentChan(1, 100.0f, FADE_MS, false, true);
+	pwm.fadePercentChan(1, 0.0f, FADE_MS, false, true);
+	pwm.fadePercentChan(1, 50.0f, FADE_MS, false, true);
+	pwm.fadePercentChan(1, 0.0f, FADE_MS, false, true);
 	// All entries seeded — now start the cycle explicitly
 	pwm.startQueue(1);
 }

--- a/samples/SinePulse_HwPWM/app/application.cpp
+++ b/samples/SinePulse_HwPWM/app/application.cpp
@@ -77,7 +77,7 @@ void startChannel(uint8_t ch)
 	for(uint32_t i = 0; i < SEGMENTS; i++) {
 		float angle = 2.0f * float(M_PI) * float(i + 1) / float(SEGMENTS);
 		float target = PEAK_PCT * 0.5f * (1.0f - cosf(angle));
-		pwm.queueFadeChanCiePercent(ch, target, SEGMENT_MS);
+		pwm.fadePercentChan(ch, target, SEGMENT_MS, true, true);
 	}
 	pwm.startQueue(ch);
 	Serial.printf("CH%u started\n", (unsigned)ch);

--- a/samples/StaggeredFade_HwPWM/app/application.cpp
+++ b/samples/StaggeredFade_HwPWM/app/application.cpp
@@ -61,9 +61,9 @@ void startChannel(uint8_t ch)
 {
 	pwm.setQueueMode(ch, Esp32HardwarePwm::QueueMode::CYCLIC);
 	pwm.setQueueCapacity(ch, 3);
-	pwm.queueFadePercentChanCie1931(ch, PEAK_PCT, ATTACK_MS);	 // 0% → 80%
-	pwm.queueFadePercentChanCie1931(ch, RELEASE_PCT, RELEASE_MS); // 80% → 10%
-	pwm.queueFadePercentChan(ch, 0, 600);						  // 10% → 0%
+	pwm.fadePercentChan(ch, PEAK_PCT, ATTACK_MS, true, true);	   // 0% → 80%
+	pwm.fadePercentChan(ch, RELEASE_PCT, RELEASE_MS, true, true); // 80% → 10%
+	pwm.fadePercentChan(ch, 0, 600, false, true);						  // 10% → 0%
 
 	pwm.startQueue(ch);
 	Serial.printf("CH%u started\n", (unsigned)ch);

--- a/samples/TimingTest_HwPWM/app/application.cpp
+++ b/samples/TimingTest_HwPWM/app/application.cpp
@@ -121,7 +121,7 @@ void pushMicroSteps()
 	// Reload overhead correction is applied automatically by the library
 	// (1 PWM period + DISPATCH_LATENCY_US per step, via carry accumulator).
 	while(stepsPushed < TOTAL_STEPS) {
-		if(!pwm->queueFadePercentChan(CH_MICRO, stepDuty(stepsPushed), MICROFADE_MS))
+				if(!pwm->fadePercentChan(CH_MICRO, stepDuty(stepsPushed), MICROFADE_MS, false, true))
 			break;
 		++stepsPushed;
 	}
@@ -258,13 +258,13 @@ void runConfig(size_t idx)
 			halfSeg = 1;
 		pwm->setQueueMode(CH_TRI, Esp32HardwarePwm::QueueMode::CYCLIC);
 		pwm->setQueueCapacity(CH_TRI, (uint16_t)(2u * halfSeg));
-		pwm->queueFadePercentChan(CH_TRI, 100.0f, 300); // 0% → 100% in 300 ms
-		pwm->queueFadePercentChan(CH_TRI, 0.0f, 300);   // 100% → 0% in 300 ms
+				pwm->fadePercentChan(CH_TRI, 100.0f, 300, false, true); // 0% → 100% in 300 ms
+				pwm->fadePercentChan(CH_TRI, 0.0f, 300, false, true);   // 100% → 0% in 300 ms
 		pwm->startQueue(CH_TRI);
 	}
 
 	tStart = esp_timer_get_time();
-	pwm->queueFadePercentChan(CH_SINGLE, 100.0f, TOTAL_FADE_MS);
+		pwm->fadePercentChan(CH_SINGLE, 100.0f, TOTAL_FADE_MS, false, true);
 	pushMicroSteps();
 
 	Serial.printf("Running... (~%lu s)\n", (unsigned long)(TOTAL_FADE_MS / 1000));

--- a/src/Esp32HardwarePwm.cpp
+++ b/src/Esp32HardwarePwm.cpp
@@ -496,29 +496,21 @@ bool Esp32HardwarePwm::fadeHwChan(uint8_t channel_idx, uint32_t target_duty, uin
 	return true;
 }
 
-bool Esp32HardwarePwm::fadeToValueChan(uint8_t channel_idx, uint32_t target_duty, uint32_t fade_time_ms)
+bool Esp32HardwarePwm::fadeChan(uint8_t channel_idx, uint32_t target_duty, uint32_t fade_time_ms, bool queue)
 {
+	if(queue)
+		return queueDutyChan(channel_idx, target_duty, fade_time_ms);
 	if(channel_idx >= pins_.size())
 		return false;
 	// Remember whether the channel is mid-fade before we clear the queue.
-	// queueFadeChan's auto-start only fires when the channel is idle, so if a
+	// queueDutyChan's auto-start only fires when the channel is idle, so if a
 	// fade was running we must force-start the new entry ourselves after enqueue.
 	bool wasFading = isFadingChan(channel_idx);
 	resetQueue(channel_idx);
-	bool ok = queueFadeChan(channel_idx, target_duty, fade_time_ms);
+	bool ok = queueDutyChan(channel_idx, target_duty, fade_time_ms);
 	if(ok && wasFading)
 		startNextFade(channel_idx); // preempts in-progress hw fade on this channel only
 	return ok;
-}
-
-bool Esp32HardwarePwm::fadeToPercentChan(uint8_t channel_idx, float target_pct, uint32_t fade_time_ms)
-{
-	if(target_pct < 0.0f)
-		target_pct = 0.0f;
-	if(target_pct > 100.0f)
-		target_pct = 100.0f;
-	uint32_t target_duty = static_cast<uint32_t>((target_pct / 100.0f) * getMaxDuty());
-	return fadeToValueChan(channel_idx, target_duty, fade_time_ms);
 }
 
 bool Esp32HardwarePwm::isFadingChan(uint8_t channel_idx) const
@@ -858,7 +850,7 @@ bool Esp32HardwarePwm::startNextFade(uint8_t channel_idx)
 			return false;
 		// Mark channel as "fading" so isFadingChan() returns true for the
 		// duration of the steady-hold.  Without this a caller can re-enter
-		// fadeToValueChan / queueFadeChan before the timer fires, corrupt the
+		// fadeChan before the timer fires, corrupt the
 		// queue, and lose the pending callback.
 		fadeDone_[channel_idx] = false;
 		q.activeIsIntermediate = entry.isPartial;
@@ -997,10 +989,10 @@ uint32_t Esp32HardwarePwm::getReloadOverheadUs(uint8_t channel) const
 	return fadeQueues_[channel].reloadOverheadUs;
 }
 
-bool Esp32HardwarePwm::queueFadeChan(uint8_t channel, uint32_t targetDuty, uint32_t fadeTimeMs)
+bool Esp32HardwarePwm::queueDutyChan(uint8_t channel, uint32_t targetDuty, uint32_t fadeTimeMs)
 {
 	if(!initialized_ || !fadeInstalled_ || channel >= pins_.size()) {
-		debug_e("queueFadeChan: not initialized, fade not installed, or channel %d out of range", channel);
+		debug_e("queueDutyChan: not initialized, fade not installed, or channel %d out of range", channel);
 		return false;
 	}
 
@@ -1062,7 +1054,7 @@ bool Esp32HardwarePwm::queueFadeChan(uint8_t channel, uint32_t targetDuty, uint3
 		// Minimum frequency needed to reach cycle_num == SPLIT_STEP_QUALITY for this fade:
 		//   freq_min = SPLIT_STEP_QUALITY * 1000 * rangeAbs / fadeTimeMs
 		uint32_t freq_min = (uint32_t)(((uint64_t)SPLIT_STEP_QUALITY * 1000ULL * rangeAbs) / fadeTimeMs);
-		debug_w("queueFadeChan: ch%d cycle_num=%llu (< %lu) — fade may be %lld ms short (hw limit). "
+		debug_w("queueDutyChan: ch%d cycle_num=%llu (< %lu) — fade may be %lld ms short (hw limit). "
 				"Fix: increase fadeTimeMs, lower resolution, or raise frequency to >= %lu Hz",
 				channel, (unsigned long long)cycle_num, (unsigned long)SPLIT_STEP_QUALITY,
 				(long long)((int64_t)fadeTimeMs - (int64_t)(t_actual_us / 1000)), (unsigned long)freq_min);
@@ -1077,18 +1069,18 @@ bool Esp32HardwarePwm::queueFadeChan(uint8_t channel, uint32_t targetDuty, uint3
 	// timing error, but the fade will still execute.
 	if(nSegs > 1 && currentCount + nSegs > (uint16_t)q.entries.size()) {
 		if(currentCount + 1 <= (uint16_t)q.entries.size()) {
-			debug_w("queueFadeChan: ch%d split (%d segs) won't fit, falling back to unsplit", channel, nSegs);
+			debug_w("queueDutyChan: ch%d split (%d segs) won't fit, falling back to unsplit", channel, nSegs);
 			if(onQueueError_)
 				onQueueError_(channel, QueueError::SPLIT_DEGRADED);
 			nSegs = 1;
 		} else {
-			debug_d("queueFadeChan: channel %d queue full (%d entries, need %d slots)", channel, currentCount, nSegs);
+			debug_d("queueDutyChan: channel %d queue full (%d entries, need %d slots)", channel, currentCount, nSegs);
 			if(onQueueError_)
 				onQueueError_(channel, QueueError::QUEUE_FULL);
 			return false;
 		}
 	} else if(nSegs == 1 && currentCount + 1 > (uint16_t)q.entries.size()) {
-		debug_d("queueFadeChan: channel %d queue full", channel);
+		debug_d("queueDutyChan: channel %d queue full", channel);
 		if(onQueueError_)
 			onQueueError_(channel, QueueError::QUEUE_FULL);
 		return false;

--- a/src/include/Esp32HardwarePwm.h
+++ b/src/include/Esp32HardwarePwm.h
@@ -67,13 +67,13 @@
  * - Spread spectrum modulation for EMI reduction
  *
  * **Hardware fading**
- * - Single-shot linear fades: `fadeToValueChan` / `fadeToPercentChan`
+ * - Single-shot linear fades: `fadeChan` / `fadePercentChan`
  * - Automatic splitting of large-range fades to avoid the LEDC
  *   `step_num ≤ 1023` quantisation limit (up to −18 % timing error at 12-bit
  *   without splitting)
  *
  * **Fade queue**
- * - Per-channel ring-buffer queue (`queueFadeChan`) in FIFO or CYCLIC mode
+ * - Per-channel ring-buffer queue (`fadeChan(..., queue=true)`) in FIFO or CYCLIC mode
  * - FIFO: auto-starts on first entry; fires `onQueueEmpty` when drained
  * - CYCLIC: seeded then started with `startQueue`; fires `onCyclicWrap` on
  *   each loop
@@ -272,29 +272,32 @@ public:
      * @param channel Channel index
      * @param percentage Duty cycle percentage (0.0 to 100.0)
      * @param update_immediately Apply changes immediately (default: true)
+     * @param cie Apply CIE 1931 perceptual correction (default: false)
      * @return true if successful, false otherwise
      */
-	bool setDutyChanPercent(uint8_t channel, DutyCycle percentage, bool update_immediately = true)
+	bool setDutyChanPercent(uint8_t channel, DutyCycle percentage, bool update_immediately = true, bool cie = false)
 	{
 		if(percentage < 0.0f)
 			percentage = 0.0f;
 		if(percentage > 100.0f)
 			percentage = 100.0f;
-		uint32_t duty = static_cast<uint32_t>(percentage * getMaxDuty() / 100.0f);
-		return setDutyChan(channel, duty, update_immediately);
+		float Y = cie ? cie1931Linear(percentage) : (percentage / 100.0f);
+		return setDutyChan(channel, static_cast<uint32_t>(Y * getMaxDuty()), update_immediately);
 	}
 
 	/** @brief Get duty cycle for a channel as a percentage
      * @param channel Channel index
+     * @param cie Return CIE 1931 perceptual percentage (default: false = linear)
      * @return Duty cycle percentage (0.0 to 100.0)
      */
-	DutyCycle getDutyChanPercent(uint8_t channel)
+	DutyCycle getDutyChanPercent(uint8_t channel, bool cie = false)
 	{
 		uint32_t duty = getDutyChan(channel);
 		uint32_t max_duty = getMaxDuty();
 		if(max_duty == 0)
 			return 0.0f;
-		return (static_cast<float>(duty) / max_duty) * 100.0f;
+		float Y = static_cast<float>(duty) / max_duty;
+		return cie ? cie1931Inverse(Y) : (Y * 100.0f);
 	}
 
 	/** @brief Set phase shift for a channel (absolute hpoint value)
@@ -330,21 +333,35 @@ public:
 	/** @brief Disable hardware fade functionality */
 	void disableFade();
 
-	/** @brief Start hardware linear fade on a channel (absolute target)
-     * @param channel_idx Channel index
-     * @param target_duty Target duty value (0 to getMaxDuty())
-     * @param fade_time_ms Duration in milliseconds
-     * @return true if started successfully
-     */
-	bool fadeToValueChan(uint8_t channel_idx, uint32_t target_duty, uint32_t fade_time_ms);
+	/** @brief Hardware linear fade on a channel (absolute duty target).
+	 * @param channel_idx Channel index
+	 * @param target_duty Target duty value (0 to getMaxDuty())
+	 * @param fade_time_ms Duration in milliseconds
+	 * @param queue If false (default), resets the queue and starts immediately.
+	 *              If true, enqueues the fade for sequential playback.
+	 * @return true if started/enqueued successfully
+	 */
+	bool fadeChan(uint8_t channel_idx, uint32_t target_duty, uint32_t fade_time_ms, bool queue = false);
 
-	/** @brief Start hardware linear fade on a channel (percentage target)
-     * @param channel_idx Channel index
-     * @param target_pct Target duty as percentage (0.0–100.0)
-     * @param fade_time_ms Duration in milliseconds
-     * @return true if started successfully
-     */
-	bool fadeToPercentChan(uint8_t channel_idx, DutyCycle target_pct, uint32_t fade_time_ms);
+	/** @brief Hardware linear fade on a channel (percentage target).
+	 * @param channel_idx Channel index
+	 * @param target_pct Target duty as percentage (0.0–100.0)
+	 * @param fade_time_ms Duration in milliseconds
+	 * @param cie Apply CIE 1931 perceptual correction (default: false)
+	 * @param queue If false (default), resets the queue and starts immediately.
+	 *              If true, enqueues the fade for sequential playback.
+	 * @return true if started/enqueued successfully
+	 */
+	bool fadePercentChan(uint8_t channel_idx, DutyCycle target_pct, uint32_t fade_time_ms, bool cie = false,
+	                     bool queue = false)
+	{
+		if(target_pct < 0.0f)
+			target_pct = 0.0f;
+		if(target_pct > 100.0f)
+			target_pct = 100.0f;
+		float Y = cie ? cie1931Linear(target_pct) : (target_pct / 100.0f);
+		return fadeChan(channel_idx, static_cast<uint32_t>(Y * getMaxDuty()), fade_time_ms, queue);
+	}
 
 	/** @brief Returns true while a hardware fade is in progress on the given channel */
 	bool isFadingChan(uint8_t channel_idx) const;
@@ -362,45 +379,7 @@ public:
 	/** @brief Get current queue mode for a channel */
 	QueueMode getQueueMode(uint8_t channel) const;
 
-	/** @brief Enqueue a fade on a channel (absolute duty target).
-	 * For FIFO queues (autoStart=true, the default), playback starts automatically
-	 * on the first entry when the channel is idle.  For CYCLIC queues
-	 * (autoStart=false by default), call startQueue() after seeding all entries.
-	 * Returns false if the queue is full.
-	 */
-	bool queueFadeChan(uint8_t channel, uint32_t targetDuty, uint32_t fadeTimeMs);
 
-	/** @brief Enqueue a fade on a channel (percentage target, 0.0–100.0) */
-	bool queueFadePercentChan(uint8_t channel, float targetPct, uint32_t fadeTimeMs)
-	{
-		if(targetPct < 0.0f)
-			targetPct = 0.0f;
-		if(targetPct > 100.0f)
-			targetPct = 100.0f;
-		return queueFadeChan(channel, static_cast<uint32_t>(targetPct / 100.0f * getMaxDuty()), fadeTimeMs);
-	}
-
-	/** @brief Set duty cycle for a channel using CIE 1931 perceptual percentage (0.0–100.0).
-	 * Converts a perceptually-uniform lightness value to a linear hardware duty.
-	 */
-	bool setDutyChanCiePercent(uint8_t channel, DutyCycle percentage, bool update_immediately = true)
-	{
-		return setDutyChan(channel, static_cast<uint32_t>(cie1931Linear(percentage) * getMaxDuty()),
-						   update_immediately);
-	}
-
-	/** @brief Fade a channel to a CIE 1931 perceptual percentage target (0.0–100.0). */
-	bool fadeToPercentChanCie(uint8_t channel_idx, DutyCycle target_pct, uint32_t fade_time_ms)
-	{
-		return fadeToValueChan(channel_idx, static_cast<uint32_t>(cie1931Linear(target_pct) * getMaxDuty()),
-							   fade_time_ms);
-	}
-
-	/** @brief Enqueue a fade on a channel to a CIE 1931 perceptual percentage target (0.0–100.0). */
-	bool queueFadeChanCiePercent(uint8_t channel, DutyCycle targetPct, uint32_t fadeTimeMs)
-	{
-		return queueFadeChan(channel, static_cast<uint32_t>(cie1931Linear(targetPct) * getMaxDuty()), fadeTimeMs);
-	}
 	uint16_t getQueueEntries(uint8_t channel) const;
 
 	/** @brief Clear the queue for a channel and reset mode to FIFO.
@@ -433,7 +412,7 @@ public:
 	 */
 	void setQueueAutoStart(uint8_t channel, bool autoStart);
 
-	/** @brief Returns true if the queue starts automatically on first queueFadeChan() call */
+	/** @brief Returns true if the queue starts automatically on first fadeChan(..., queue=true) call */
 	bool getQueueAutoStart(uint8_t channel) const;
 
 	// -----------------------------------------------------------------------
@@ -496,7 +475,7 @@ public:
 		onCyclicWrap_ = cb;
 	}
 
-	/** @brief Callback fired when a queueFadeChan call fails or degrades.
+	/** @brief Callback fired when a fadeChan(queue=true) call fails or degrades.
 	 *  The callback receives the channel index and the QueueError reason.
 	 *  For QUEUE_FULL the fade was not enqueued; for SPLIT_DEGRADED the fade
 	 *  was enqueued unsplit (hardware timing accuracy may be reduced). */
@@ -527,13 +506,13 @@ public:
 	// Legacy interface — GPIO-pin-indexed (use channel interface for new code)
 	// -----------------------------------------------------------------------
 
-	/** @brief Set PWM duty cycle for a specific pin (legacy)
+	/** @brief Set PWM duty cycle for a specific pin (legacy pin-indexed interface)
      * @param pin GPIO pin number
      * @param duty Duty cycle value (0 to getMaxDuty())
      * @param update_immediately Apply changes immediately (default: true)
      * @return true if successful, false otherwise
      */
-	bool setDuty(uint8_t pin, uint32_t duty, bool update_immediately = true)
+	bool setDutyPin(uint8_t pin, uint32_t duty, bool update_immediately = true)
 	{
 		int idx = getPinIndex(pin);
 		if(idx < 0)
@@ -541,11 +520,11 @@ public:
 		return setDutyChan((uint8_t)idx, duty, update_immediately);
 	}
 
-	/** @brief Get PWM duty cycle for a specific pin (legacy)
+	/** @brief Get PWM duty cycle for a specific pin (legacy pin-indexed interface)
      * @param pin GPIO pin number
      * @return Current duty cycle value
      */
-	uint32_t getDuty(uint8_t pin)
+	uint32_t getDutyPin(uint8_t pin)
 	{
 		int idx = getPinIndex(pin);
 		if(idx < 0)
@@ -560,7 +539,7 @@ public:
      */
 	bool analogWrite(uint8_t pin, uint32_t duty)
 	{
-		return setDuty(pin, duty);
+		return setDutyPin(pin, duty);
 	}
 
 	/** @brief Start PWM output on a specific pin (legacy)
@@ -580,6 +559,9 @@ public:
 	void startAll();
 
 private:
+	/** @brief Internal: enqueue a fade (absolute duty). Used by fadeChan(). */
+	bool queueDutyChan(uint8_t channel, uint32_t targetDuty, uint32_t fadeTimeMs);
+
 	struct FadeEntry {
 		uint32_t targetDuty;
 		uint32_t fadeTimeMs;
@@ -593,7 +575,7 @@ private:
 		uint16_t count = 0;				///< FIFO: decrements on pop; CYCLIC: fixed after seeding
 		uint16_t cycleLen = 0;			///< CYCLIC: number of entries in the cycle
 		QueueMode mode = QueueMode::FIFO;
-		bool autoStart = true; ///< If true, playback starts on first queueFadeChan(); false requires startQueue()
+		bool autoStart = true; ///< If true, playback starts on first fadeChan(queue=true); false requires startQueue()
 		uint32_t reloadOverheadUs = 0;	 ///< Per-reload overhead subtracted from each step (µs)
 		int32_t carryUs = 0;			   ///< Sub-ms accumulator for reload overhead correction
 		int32_t quantCarryUs = 0;		   ///< Sub-µs accumulator for cycle_num truncation correction
@@ -736,6 +718,21 @@ private:
 			return L / 902.3f;
 		float t = (L + 16.0f) / 116.0f;
 		return t * t * t;
+	}
+
+	// CIE 1931 inverse: maps linear duty fraction Y (0–1) back to perceptual
+	// lightness L (0–100).  Inverse of cie1931Linear.
+	//   Y <= 0.008856  →  L = 903.3 × Y
+	//   Y  > 0.008856  →  L = 116 × ∛Y − 16
+	static float cie1931Inverse(float Y)
+	{
+		if(Y <= 0.0f)
+			return 0.0f;
+		if(Y >= 1.0f)
+			return 100.0f;
+		if(Y <= 0.008856f)
+			return Y * 903.3f;
+		return 116.0f * cbrtf(Y) - 16.0f;
 	}
 };
 


### PR DESCRIPTION
Replace four separate functions with two orthogonal ones:

  fadeChan(ch, duty, ms, queue=false)
  fadePercentChan(ch, pct, ms, cie=false, queue=false)

- queue=false (default): resets queue and starts immediately (was fadeDutyChan)
- queue=true:  enqueues for sequential playback (was queueDutyChan)
- cie=true:    applies CIE 1931 perceptual correction (was separate *Cie* variants)

Removed: fadeDutyChan, fadeDutyChanPercent, queueDutyChan (public),
         queueDutyChanPercent
queueDutyChan moved to private as the internal implementation worker.

Updated all sample apps and README API reference.